### PR TITLE
mapStateToProps provides ownProps as Object

### DIFF
--- a/packages/iflow-react-redux/index.js.flow
+++ b/packages/iflow-react-redux/index.js.flow
@@ -6,7 +6,7 @@ declare module 'react-redux' {
     getWrappedInstance(): React.Component;
   }
   declare var Provider: React.Component;
-  declare function connect(mapStateToProps?: (state: Object, ownProps?: any) => Object, mapDispatchToProps?: any, mergeProps?: (stateProps: any, dispatchProps: any, ownProps: any) => any, options?: {
+  declare function connect(mapStateToProps?: (state: Object, ownProps: Object) => Object, mapDispatchToProps?: any, mergeProps?: (stateProps: any, dispatchProps: any, ownProps: any) => any, options?: {
     pure?: bool,
     withRef?: bool,
   }): (component: React.Component) => ConnectedReactClass;


### PR DESCRIPTION
First off, I'm totally willing to be wrong on this one!

I'm pretty sure the flow signature for `connect`'s `mapStateToProps` should be
`(state: Object, ownProps: Object) => Object`
instead of 
`(state: Object, ownProps?: any) => Object`

This does not mean that a `mapStateToProps` implementation must accept a second argument for `ownProps`, only that if it does it will be an object (not a nullable type, that's the important part)
