### PR TITLE
Redux - fix combineReducers; add createStore, applyMiddleware, compose 

### DIFF
--- a/packages/iflow-redux/index.js.flow
+++ b/packages/iflow-redux/index.js.flow
@@ -2,6 +2,9 @@ declare module 'redux' {
   declare class Redux {
     bindActionCreators(actionCreators: Object, dispatch: Function): Object;
     combineReducers(reducers: Object): Function;
+    createStore(reducer: Function, initialState?: any, enhancer?: Function): Object;
+    applyMiddleware(): Function;
+    compose(): Function;
   }
   declare var exports: Redux;
 }

--- a/packages/iflow-redux/index.js.flow
+++ b/packages/iflow-redux/index.js.flow
@@ -1,7 +1,7 @@
 declare module 'redux' {
   declare class Redux {
     bindActionCreators(actionCreators: Object, dispatch: Function): Object;
-    combineReducers(reducers: Object): Object;
+    combineReducers(reducers: Object): Function;
   }
   declare var exports: Redux;
 }


### PR DESCRIPTION
combineReducers returns a function (http://redux.js.org/docs/api/combineReducers.html)

Adding basic implementations of Redux's createStore, applyMiddleware, compose from the docs. applyMiddleware and compose arguments are still not typed.
