### PR TITLE
fix(iflow-koa): Fix koa.use() function signature

### DIFF
--- a/packages/iflow-koa/index.js.flow
+++ b/packages/iflow-koa/index.js.flow
@@ -154,7 +154,7 @@ declare module 'koa' {
     listen(port: number): void;
     callback(): Function;
     keys: string[] | Object;
-    use(contextFn: (ctx?: Context, next?: Function) => ?Promise): this;
+    use(contextFn: (ctx: Context, next: Function) => ?Promise): this;
   }
   declare var exports: Class<Koa>;
 }


### PR DESCRIPTION
Ensure context & next parameters are not optional, and therefore don't have to be checked in the implementation.
