### PR TITLE
Update: add better type annoations for redux

### DIFF
--- a/packages/iflow-redux/index.js.flow
+++ b/packages/iflow-redux/index.js.flow
@@ -1,10 +1,29 @@
 declare module 'redux' {
+  declare type State = any;
+  declare type Action = Object;
+  declare type AsyncAction = any;
+  declare type Reducer<S, A> = (state: S, action: A) => S;
+  declare type BaseDispatch = (a: Action) => Action;
+  declare type Dispatch = (a: Action | AsyncAction) => any;
+  declare type ActionCreator = (...args: any) => Action | AsyncAction;
+  declare type MiddlewareAPI = { dispatch: Dispatch, getState: () => State };
+  declare type Middleware = (api: MiddlewareAPI) => (next: Dispatch) => Dispatch;
+  declare type Store = {
+    dispatch: Dispatch,
+    getState: () => State,
+    subscribe: (listener: () => void) => () => void,
+    replaceReducer: (reducer: Reducer) => void
+  };
+  declare type StoreCreator = (reducer: Reducer, initialState: ?State) => Store;
+  declare type StoreEnhancer = (next: StoreCreator) => StoreCreator;
+  declare type ActionCreatorOrObjectOfACs = ActionCreator | { [key: string]: ActionCreator };
+  declare type Reducers = { [key: string]: Reducer };
   declare class Redux {
-    bindActionCreators(actionCreators: Object, dispatch: Function): Object;
-    combineReducers(reducers: Object): Function;
-    createStore(reducer: Function, initialState?: any, enhancer?: Function): Object;
-    applyMiddleware(): Function;
-    compose(): Function;
+    bindActionCreators<actionCreators: ActionCreatorOrObjectOfACs>(actionCreators: actionCreators, dispatch: Dispatch): actionCreators;
+    combineReducers(reducers: Reducers): Reducer;
+    createStore(reducer: Reducer, initialState?: State, enhancer?: StoreEnhancer): Store;
+    applyMiddleware(...middlewares: Array<Middleware>): StoreEnhancer;
+    compose(...functions: Array<Function | StoreEnhancer>): Function;
   }
   declare var exports: Redux;
 }

--- a/packages/iflow-redux/package.json
+++ b/packages/iflow-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iflow-redux",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Flow Interface for redux",
   "main": "index.js.flow",
   "scripts": {


### PR DESCRIPTION
- add type aliases to module from [glossary page](http://redux.js.org/docs/Glossary.html).
- annotate the exported Redux class.
