### PR TITLE
(iflow-immutable): fix `Iterable` clash in `fromJS`

### DIFF
--- a/packages/iflow-immutable/index.js.flow
+++ b/packages/iflow-immutable/index.js.flow
@@ -23,45 +23,6 @@
 
 declare module 'immutable' {
 
-  /**
-   * Deeply converts plain JS objects and arrays to Immutable Maps and Lists.
-   *
-   * If a `reviver` is optionally provided, it will be called with every
-   * collection as a Seq (beginning with the most nested collections
-   * and proceeding to the top-level collection itself), along with the key
-   * referring to each collection and the parent JS object provided as `this`.
-   * For the top level, object, the key will be `""`. This `reviver` is expected
-   * to return a new Immutable Iterable, allowing for custom convertions from
-   * deep JS objects.
-   *
-   * This example converts JSON to List and OrderedMap:
-   *
-   *     Immutable.fromJS({a: {b: [10, 20, 30]}, c: 40}, function (key, value) {
-   *       var isIndexed = Immutable.Iterable.isIndexed(value);
-   *       return isIndexed ? value.toList() : value.toOrderedMap();
-   *     });
-   *
-   *     // true, "b", {b: [10, 20, 30]}
-   *     // false, "a", {a: {b: [10, 20, 30]}, c: 40}
-   *     // false, "", {"": {a: {b: [10, 20, 30]}, c: 40}}
-   *
-   * If `reviver` is not provided, the default behavior will convert Arrays into
-   * Lists and Objects into Maps.
-   *
-   * `reviver` acts similarly to the [same parameter in `JSON.parse`][1].
-   *
-   * `Immutable.fromJS` is conservative in it's conversion. It will only convert
-   * arrays which pass `Array.isArray` to Lists, and only raw objects (no custom
-   * prototype) to Map.
-   *
-   * [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter
-   *      "Using the reviver parameter"
-   */
-  declare function fromJS(
-    json: any,
-    reviver?: (k: any, v: Iterable<any, any>) => any
-  ): any;
-
 
   /**
    * Value equality check with semantics similar to `Object.is`, but treats
@@ -2370,4 +2331,44 @@ declare module 'immutable' {
    *
    */
   declare function Repeat<T>(value: T, times?: number): IndexedSeq<T>;
+  
+  
+  /**
+   * Deeply converts plain JS objects and arrays to Immutable Maps and Lists.
+   *
+   * If a `reviver` is optionally provided, it will be called with every
+   * collection as a Seq (beginning with the most nested collections
+   * and proceeding to the top-level collection itself), along with the key
+   * referring to each collection and the parent JS object provided as `this`.
+   * For the top level, object, the key will be `""`. This `reviver` is expected
+   * to return a new Immutable Iterable, allowing for custom convertions from
+   * deep JS objects.
+   *
+   * This example converts JSON to List and OrderedMap:
+   *
+   *     Immutable.fromJS({a: {b: [10, 20, 30]}, c: 40}, function (key, value) {
+   *       var isIndexed = Immutable.Iterable.isIndexed(value);
+   *       return isIndexed ? value.toList() : value.toOrderedMap();
+   *     });
+   *
+   *     // true, "b", {b: [10, 20, 30]}
+   *     // false, "a", {a: {b: [10, 20, 30]}, c: 40}
+   *     // false, "", {"": {a: {b: [10, 20, 30]}, c: 40}}
+   *
+   * If `reviver` is not provided, the default behavior will convert Arrays into
+   * Lists and Objects into Maps.
+   *
+   * `reviver` acts similarly to the [same parameter in `JSON.parse`][1].
+   *
+   * `Immutable.fromJS` is conservative in it's conversion. It will only convert
+   * arrays which pass `Array.isArray` to Lists, and only raw objects (no custom
+   * prototype) to Map.
+   *
+   * [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter
+   *      "Using the reviver parameter"
+   */
+  declare function fromJS(
+    json: any,
+    reviver?: (k: any, v: Iterable<any, any>) => any
+  ): any;
 }


### PR DESCRIPTION
Having the declaration for `fromJS` come before `Iterable` leads to an error about too many type arguments to `Iterable`, because Flow includes a global declaration of `Iterable` with only 1 type parameter, that is not yet shadowed by Immutables's module-local declaration.

(see file flow/lib/core.js -- https://github.com/facebook/flow/blob/57413d9bcb14aaa1a62917e0926a1806863851e8/lib/core.js)
