### PR TITLE
(iflow-immutable): fix conversion return types

### DIFF
--- a/packages/iflow-immutable/index.js.flow
+++ b/packages/iflow-immutable/index.js.flow
@@ -1409,7 +1409,7 @@ declare module 'immutable' {
      * Note: This is equivalent to `OrderedMap(this.toKeyedSeq())`, but
      * provided for convenience and to allow for chained expressions.
      */
-    toOrderedMap(): Map<K, V>;
+    toOrderedMap(): OrderedMap<K, V>;
 
     /**
      * Converts this Iterable to a Set, discarding keys. Throws if values
@@ -1427,7 +1427,7 @@ declare module 'immutable' {
      * Note: This is equivalent to `OrderedSet(this.valueSeq())`, but provided
      * for convenience and to allow for chained expressions.
      */
-    toOrderedSet(): Set<V>;
+    toOrderedSet(): OrderedSet<V>;
 
     /**
      * Converts this Iterable to a List, discarding keys.


### PR DESCRIPTION
toOrderedMap, toOrderedSet
