### PR TITLE
Update: Fix return type for handleAction and handleActions

### DIFF
--- a/packages/iflow-redux-actions/index.js.flow
+++ b/packages/iflow-redux-actions/index.js.flow
@@ -1,5 +1,7 @@
+import type { Reducer as ReduxReducer } from 'redux';
+
 declare module 'redux-actions' {
   declare function createAction(type: string, payloadCreator?: Function, metaCreator?: Function): any;
-  declare function handleAction(type: string, reducer: Object|Function): void;
-  declare function handleActions(reducerMap: Object, defaultState?: Object): void;
+  declare function handleAction(type: string, reducer: Object|Function): ReduxReducer;
+  declare function handleActions(reducerMap: Object, defaultState?: Object): ReduxReducer;
 }


### PR DESCRIPTION
Discovered this issue when trying to pass the return value of `handleActions` to `combineReducers`. 

``` javascript
const login = handleActions(...)
```

<img width="829" alt="screen shot 2016-05-06 at 4 44 24 pm" src="https://cloud.githubusercontent.com/assets/830026/15088502/d2a8763c-13a9-11e6-835f-4f23d4517ba8.png">

I couldn't import `Reducer` directly without assigning it an alias. If I did, it seemed to screw up the type declaration so that importing it later would cause this flow error...

<img width="962" alt="screen shot 2016-05-06 at 4 48 18 pm" src="https://cloud.githubusercontent.com/assets/830026/15088532/63fc72dc-13aa-11e6-8f70-35415783ae9b.png">
