### PR TITLE
lodash: add real support for chaining

### DIFF
--- a/packages/iflow-lodash/.flowconfig
+++ b/packages/iflow-lodash/.flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+
+[include]
+
+[libs]
+./index.js.flow
+
+[options]

--- a/packages/iflow-lodash/index.js.flow
+++ b/packages/iflow-lodash/index.js.flow
@@ -244,8 +244,7 @@ declare module 'lodash' {
     once(func: Function): Function;
     overArgs(func: Function, ...transforms: Array<Function>): Function;
     overArgs(func: Function, transforms: Array<Function>): Function;
-    partial(func: Function, ...partials: Array<any>): Function;
-    partial(func: Function, partials: Array<any>): Function;
+    partial(func: Function, ...partials: any[]): Function;
     partialRight(func: Function, ...partials: Array<any>): Function;
     partialRight(func: Function, partials: Array<any>): Function;
     rearg(func: Function, ...indexes: Array<number>): Function;

--- a/packages/iflow-lodash/index.js.flow
+++ b/packages/iflow-lodash/index.js.flow
@@ -47,6 +47,11 @@ type Iteratee2<T, U> = ((item: T, index: number, array: ?Array<T>) => U)|Object|
 type FlatMapIteratee<T, U> = ((item: T, index: number, array: ?Array<T>) => Array<U>)|Object|string;
 type Comparator<T> = (item: T, item2: T) => bool;
 
+type MapIterator1<T,U> = (item: T) => U;
+type MapIterator2<T,U> = (item: T, index: number) => U;
+type MapIterator3<T,U> = (item: T, index: number, array: Array<T>) => U;
+type MapIterator<T,U> = MapIterator1<T,U>|MapIterator2<T,U>|MapIterator3<T,U>;
+
 declare module 'lodash' {
   declare class Lodash {
     (value: any): any;
@@ -189,7 +194,7 @@ declare module 'lodash' {
     keyBy<T>(array: ?Array<T>, iteratee?: Iteratee<T>): Object;
     keyBy<V, T: Object>(object: T, iteratee?: OIteratee<T>): Object;
 
-    map<T, U>(array: ?Array<T>, iteratee?: Iteratee2<T, U>): Array<U>;
+    map<T, U>(array: Array<T>, iteratee?: MapIterator<T, U>): Array<U>;
     map<V, T: Object, U>(object: T, iteratee?: OIterateeWithResult<V, T, U>): Array<U>;
     map(str: string, iteratee?: (char: string, index: number, str: string) => any): string;
 

--- a/packages/iflow-lodash/index.js.flow
+++ b/packages/iflow-lodash/index.js.flow
@@ -279,7 +279,8 @@ declare module 'lodash' {
     isEqualWith<T, U>(value: T, other: U, customizer?: (objValue: any, otherValue: any, key: number|string, object: T, other: U, stack: any) => bool|void): bool;
     isError(value: any): bool;
     isFinite(value: any): bool;
-    isFunction(value: any): bool;
+    isFunction(value: Function): true;
+    isFunction(value: number|string|void|null|Object): false;
     isInteger(value: any): bool;
     isLength(value: any): bool;
     isMatch(object?: ?Object, source: Object): bool;

--- a/packages/iflow-lodash/index.js.flow
+++ b/packages/iflow-lodash/index.js.flow
@@ -389,7 +389,7 @@ declare module 'lodash' {
     result(object?: ?Object, path?: ?Array<string>|string, defaultValue?: any): any;
     set(object?: ?Object, path?: ?Array<string>|string, value: any): Object;
     setWith<T>(object: T, path?: ?Array<string>|string, value: any, customizer?: (nsValue: any, key: string, nsObject: T) => any): Object;
-    toPairs(object?: ?Object): NestedArray<any>;
+    toPairs(object?: ?Object|Array<*>): NestedArray<any>;
     entries(object?: ?Object): NestedArray<any>;
     toPairsIn(object?: ?Object): NestedArray<any>;
     entriesIn(object?: ?Object): NestedArray<any>;

--- a/packages/iflow-lodash/index.js.flow
+++ b/packages/iflow-lodash/index.js.flow
@@ -37,7 +37,10 @@ type OPredicate<O> = ((value: any, key: string, object: O) => ?bool)|Object|stri
 type OIterateeWithResult<V, O, R> = ((value: V, key: string, object: O) => R)|Object|string;
 type OIteratee<O> = OIterateeWithResult<any, O, any>;
 
-type Predicate<T> = ((value: T, index: number, array: ?Array<T>) => ?bool)|Object|string;
+type Predicate<T> = ((value: T, index: number, array: Array<T>) => ?bool)
+                  | ((value: T, index: number) => ?bool)
+                  | ((value: T) => ?bool)
+                  | Object | string;
 type _Iteratee<T> = (item: T, index: number, array: ?Array<T>) => mixed;
 type Iteratee<T> = _Iteratee<T>|Object|string;
 type Iteratee2<T, U> = ((item: T, index: number, array: ?Array<T>) => U)|Object|string;

--- a/packages/iflow-lodash/package.json
+++ b/packages/iflow-lodash/package.json
@@ -4,7 +4,7 @@
   "description": "Flow Interface for lodash",
   "main": "index.js.flow",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "flow check"
   },
   "keywords": [
     "flowInterface",
@@ -13,5 +13,8 @@
     "iflow"
   ],
   "author": "marudor",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "lodash": "^4.13.1"
+  }
 }

--- a/packages/iflow-lodash/test-es6.js
+++ b/packages/iflow-lodash/test-es6.js
@@ -1,0 +1,26 @@
+// @flow
+
+// sanity check for default export
+import _ from 'lodash';
+
+// sanity check for named exports
+import {flatten, map} from 'lodash';
+
+var nums : Array<number> = [1,2,3,4,5,6];
+
+var seq = _(nums);
+
+var squareSeq = seq.map(function(num) {
+  return num * num;
+});
+
+var nsquares = nums.map(function(val, ind, arr) {
+  return val * val;
+});
+
+var strSeq = squareSeq.map(function(num) {
+  return JSON.stringify(num);
+});
+
+var squares = squareSeq.value();
+var strings = strSeq.value();

--- a/packages/iflow-lodash/test.js
+++ b/packages/iflow-lodash/test.js
@@ -1,0 +1,35 @@
+// @flow
+
+var lodash = require('lodash');
+
+var nums : number[] = [1,2,3,4,5,6];
+
+var seq = lodash(nums);
+var chain = lodash.chain(nums);
+var unwrapped = seq.value();
+var num = unwrapped[0];
+var unwrapped = chain.value();
+num === unwrapped[0];
+
+var squareSeq = seq.map(function(num) {
+  return num * num;
+});
+
+var nsquares = nums.map(function(val, ind, arr) {
+  return val * val;
+});
+
+nsquares = nums.map(function(val, ind) {
+  return val * val;
+});
+
+nsquares = nums.map(function(val) {
+  return val * val;
+});
+
+var strSeq = squareSeq.map(function(num) {
+  return JSON.stringify(num);
+});
+
+var squares = squareSeq.value();
+var strings = strSeq.value();


### PR DESCRIPTION
I've been floating these patches locally, tweaking them as I run in to missing cases in my project, but I want to make sure they aren't just on my local machine.

Maybe someone has some opinions on the approach I've taken to add support for typed `_.chain()`:
- make all the normal lodash functions `static` methods of a `Lodash` class
- make instance versions of all the chainable methods with the first argument removed
- make instance methos return another `Lodash` instance
- make `_.chain()` return a `Lodash` instance
