### PR TITLE
Fix lodash _.keyBy definition

### DIFF
--- a/packages/iflow-lodash/index.js.flow
+++ b/packages/iflow-lodash/index.js.flow
@@ -170,7 +170,7 @@ declare module 'lodash' {
     includes(str: string, value: string, fromIndex?: number): bool;
     invokeMap<T>(array: ?Array<T>, path: ((value: T) => Array<string>|string)|Array<string>|string, ...args?: Array<any>): Array<any>;
     invokeMap<T: Object>(object: T, path: ((value: any) => Array<string>|string)|Array<string>|string, ...args?: Array<any>): Array<any>;
-    keyBy<T>(array: ?Array<T>, iteratee?: Iteratee<T>): Object;
+    keyBy<T, V>(array: ?Array<T>, iteratee?: Iteratee2<T, V>): {[key: V]: T};
     keyBy<V, T: Object>(object: T, iteratee?: OIteratee<T>): Object;
     map<T, U>(array: ?Array<T>, iteratee?: MapIterator<T, U>): Array<U>;
     map<V, T: Object, U>(object: ?T, iteratee?: OIterateeWithResult<V, T, U>): Array<U>;


### PR DESCRIPTION
Ensures it produces an object whose keys are the same as the returned type of the iterator.
