### PR TITLE
Update `README.md`'s list of Available Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,12 @@ node_modules/iflow-lodash/index.js.flow
 
 ## Available Interfaces
 
-* iflow-axios
 * iflow-bluebird
 * iflow-chartist
-* iflow-clamp-js
-* iflow-classnames
-* iflow-color
 * iflow-core-decorators
 * iflow-debug
 * iflow-deep-diff
-* iflow-dropzone
-* iflow-eventemitter3
-* iflow-enzyme
-* iflow-fuse
 * iflow-fuzzaldrin
-* iflow-i18next
-* iflow-immutable
 * iflow-invariant
 * iflow-isomorphic-fetch
 * iflow-jquery
@@ -49,35 +39,21 @@ node_modules/iflow-lodash/index.js.flow
 * iflow-koa-bodyparser
 * iflow-koa-router
 * iflow-lodash
-* iflow-material-ui
-* iflow-moment
-* iflow-mousetrap
-* iflow-normalizr
-* iflow-notifyjs
-* iflow-pretty-error
-* iflow-primus
 * iflow-primus-emit
 * iflow-primus-rooms
-* iflow-radium
 * iflow-react-addons-test-utils
-* iflow-react-dnd
+* iflow-react-gemini-scrollbar
 * iflow-react-native-vector-icons
 * iflow-react-redux
 * iflow-react-router
 * iflow-react-router-redux
 * iflow-react-widgets
-* iflow-redux
-* iflow-redux-actions
 * iflow-redux-logger
 * iflow-redux-thunk
-* iflow-sanitize-html
 * iflow-shallowequal
 * iflow-stardust
-* iflow-underscore
-* iflow-uuid-js
 * iflow-vex
 * iflow-warning
-* iflow-yargs
 
 ## Contributing
 


### PR DESCRIPTION
I was initially thrown of by the `README.md` saying that this repo had types for Redux, when that was no longer true (which also seems to be the source of https://github.com/marudor/flowInterfaces/issues/42).

This PR simply updates the `Available Interfaces` section with the output of:

```
ls -1 packages | sed -ne's/\(.*\)/\* \1/p'
```
