### PR TITLE
fix flow >= 0.28.0 "error location of union/intersection type"

### DIFF
--- a/packages/iflow-lodash/index.js.flow
+++ b/packages/iflow-lodash/index.js.flow
@@ -26,7 +26,7 @@ type ThrottleOptions = {
 type NestedArray<T> = Array<Array<T>>;
 
 type OPredicate<O> = ((value: any, key: string, object: O) => ?bool)|Object|string;
-type OIterateeWithResult<V, O, R> = ((value: V, key: string, object: O) => R)|Object|string;
+type OIterateeWithResult<V, O, R> = Object|string|((value: V, key: string, object: O) => R);
 type OIteratee<O> = OIterateeWithResult<any, O, any>;
 
 type Predicate<T> = ((value: T, index: number, array: Array<T>) => ?bool)


### PR DESCRIPTION
Blog about this: https://flowtype.org/blog/2016/07/01/New-Unions-Intersections.html

Error:

```
139:                 const scoreFields = mapValues(calculator.result(notification), (value, field, obj)=> result(obj, field));
                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ arrow function. Could not decide which case to select
358:     mapValues(object?: ?Object, iteratee?: OIteratee<*>): Object;
                                                ^^^^^^^^^^^^ union type. See lib: node_modules/iflow-lodash/index.js.flow:358
  Case 1 may work:
   29: type OIterateeWithResult<V, O, R> = ((value: V, key: string, object: O) => R)|Object|string;
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: node_modules/iflow-lodash/index.js.flow:29
  But if it doesn't, case 2 looks promising too:
   29: type OIterateeWithResult<V, O, R> = ((value: V, key: string, object: O) => R)|Object|string;
                                                                                     ^^^^^^ object type. See lib: node_modules/iflow-lodash/index.js.flow:29
  Please provide additional annotation(s) to determine whether case 1 works (or consider merging it with case 2):
  139:                 const scoreFields = mapValues(calculator.result(notification), (value, field, obj)=> result(obj, field));
                                                                                              ^^^^^ parameter `field`

```
