### PR TITLE
Add support for multiple objects in primisifyAll

### DIFF
--- a/packages/iflow-bluebird/index.js.flow
+++ b/packages/iflow-bluebird/index.js.flow
@@ -85,7 +85,7 @@ declare class Bluebird$Promise<R> {
   static defer(): Bluebird$Defer;
   static setScheduler(scheduler: (callback: (...args: Array<any>) => void) => void): void;
   static promisify(nodeFunction: Function, receiver?: Bluebird$PromisifyOptions): Function;
-  static promisifyAll(target: Object, options?: Bluebird$PromisifyAllOptions): void;
+  static promisifyAll(target: Object | Object[], options?: Bluebird$PromisifyAllOptions): void;
 
   static coroutine(generatorFunction: Function): Function;
   static spawn<T>(generatorFunction: Function): Promise<T>;


### PR DESCRIPTION
As per Bluebird documentation, there's support for promisifying an array of objects:

http://bluebirdjs.com/docs/api/promise.promisifyall.html#promisifying-multiple-classes-in-one-go

Would be good to get this `iflow-bluebird` updated to reflect that.
