### PR TITLE
add `import React from "react"`

### DIFF
--- a/packages/iflow-react-intl/index.js.flow
+++ b/packages/iflow-react-intl/index.js.flow
@@ -1,3 +1,5 @@
+import React from 'react';
+
 // Mostly from https://github.com/yahoo/react-intl/wiki/API#react-intl-api
 
 type LocaleData = {


### PR DESCRIPTION
prevents these errors:

```
node_modules/iflow-react-intl/index.js.flow:126
126:   declare class FormattedMessage extends React.Component<void, MessageDescriptor & {
                                              ^^^^^ Library type error:
126:   declare class FormattedMessage extends React.Component<void, MessageDescriptor & {
                                              ^^^^^ mixins `React`. Could not resolve name
```
