### PR TITLE
Switches JQueryPromiseCallback from a class to an interface.

### DIFF
--- a/packages/iflow-jquery/index.js.flow
+++ b/packages/iflow-jquery/index.js.flow
@@ -311,7 +311,7 @@ declare class JQueryGenericPromise <T> {
 /**
  * Interface for the JQuery promise/deferred callbacks
  */
-declare class JQueryPromiseCallback <T> {
+declare interface JQueryPromiseCallback <T> {
   (value?: T, ...args: any[]): void;
 }
 


### PR DESCRIPTION
This means that lambda/anonymous functions will match its type
signature, and are passable to things that take a callback (like the
Promise.done()).

This closes issue #71 . Since these type definitions are copied from @DefinitelyTyped and flow supports interfaces, most of these things that are defined as classes should probably be interfaces. I didn't want to make sweeping changes though, and just tested this one.
