### PR TITLE
Fixes for jQuery overloads order

### DIFF
--- a/packages/iflow-jquery/index.js.flow
+++ b/packages/iflow-jquery/index.js.flow
@@ -1239,34 +1239,21 @@ declare class JQuery {
   /**
    * Adds the specified class(es: any) to each of the set of matched elements.
    *
-   * @param className One or more space-separated classes to be added to the class attribute of each matched element.
-   */
-  addClass(className: string): JQuery;
-  /**
-   * Adds the specified class(es: any) to each of the set of matched elements.
-   *
    * @param function A function returning one or more s: anypace-separated class names to be added to the existing class name(s). Receives the index position of the element in the set and the existing class name(s) as arguments. Within the function, this refers to the current element in the set.
    */
   addClass(func: (index: number, className: string) => string): JQuery;
+  /**
+   * Adds the specified class(es: any) to each of the set of matched elements.
+   *
+   * @param className One or more space-separated classes to be added to the class attribute of each matched element.
+   */
+  addClass(className: string): JQuery;
 
   /**
    * Add the previous set of elements on the stack to the current set, optionally filtered by a selector.
    */
   addBack(selector?: string): JQuery;
 
-  /**
-   * Get the value of an attribute for the first element in the set of matched elements.
-   *
-   * @param attributeName The name of the attribute to get.
-   */
-  attr(attributeName: string): string;
-  /**
-   * Set one or more attributes for the set of matched elements.
-   *
-   * @param attributeName The name of the attribute to set.
-   * @param value A value to set for the attribute.
-   */
-  attr(attributeName: string, value: string | number): JQuery;
   /**
    * Set one or more attributes for the set of matched elements.
    *
@@ -1277,9 +1264,22 @@ declare class JQuery {
   /**
    * Set one or more attributes for the set of matched elements.
    *
+   * @param attributeName The name of the attribute to set.
+   * @param value A value to set for the attribute.
+   */
+  attr(attributeName: string, value: string | number): JQuery;
+  /**
+   * Set one or more attributes for the set of matched elements.
+   *
    * @param attributes An object of attribute-value pairs to set.
    */
   attr(attributes: Object): JQuery;
+  /**
+   * Get the value of an attribute for the first element in the set of matched elements.
+   *
+   * @param attributeName The name of the attribute to get.
+   */
+  attr(attributeName: string): string;
 
   /**
    * Determine whether any of the matched elements are assigned the given class.

--- a/packages/iflow-jquery/index.js.flow
+++ b/packages/iflow-jquery/index.js.flow
@@ -1289,16 +1289,6 @@ declare class JQuery {
   hasClass(className: string): boolean;
 
   /**
-   * Get the HTML contents of the first element in the set of matched elements.
-   */
-  html(): string;
-  /**
-   * Set the HTML contents of each element in the set of matched elements.
-   *
-   * @param htmlString A string of HTML to set as the content of each matched element.
-   */
-  html(htmlString: string): JQuery;
-  /**
    * Set the HTML contents of each element in the set of matched elements.
    *
    * @param func A function returning the HTML content to set. Receives the index position of the element in the set and the old HTML value as arguments. jQuery empties the element before calling the function; use the oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
@@ -1307,8 +1297,13 @@ declare class JQuery {
   /**
    * Set the HTML contents of each element in the set of matched elements.
    *
-   * @param func A function returning the HTML content to set. Receives the index position of the element in the set and the old HTML value as arguments. jQuery empties the element before calling the function; use the oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
+   * @param htmlString A string of HTML to set as the content of each matched element.
    */
+  html(htmlString: string): JQuery;
+  /**
+   * Get the HTML contents of the first element in the set of matched elements.
+   */
+  html(): string;
 
   /**
    * Get the value of a property for the first element in the set of matched elements.
@@ -1402,20 +1397,6 @@ declare class JQuery {
    */
   val(func: (index: number, value: string) => string): JQuery;
 
-
-  /**
-   * Get the value of style properties for the first element in the set of matched elements.
-   *
-   * @param propertyName A CSS property.
-   */
-  css(propertyName: string): string;
-  /**
-   * Set one or more CSS properties for the set of matched elements.
-   *
-   * @param propertyName A CSS property name.
-   * @param value A value to set for the property.
-   */
-  css(propertyName: string, value: string | number): JQuery;
   /**
    * Set one or more CSS properties for the set of matched elements.
    *
@@ -1426,9 +1407,22 @@ declare class JQuery {
   /**
    * Set one or more CSS properties for the set of matched elements.
    *
+   * @param propertyName A CSS property name.
+   * @param value A value to set for the property.
+   */
+  css(propertyName: string, value: string | number): JQuery;
+  /**
+   * Set one or more CSS properties for the set of matched elements.
+   *
    * @param properties An object of property-value pairs to set.
    */
   css(properties: Object): JQuery;
+  /**
+   * Get the value of style properties for the first element in the set of matched elements.
+   *
+   * @param propertyName A CSS property.
+   */
+  css(propertyName: string): string;
 
   /**
    * Get the current computed height for the first element in the set of matched elements.
@@ -2760,10 +2754,6 @@ declare class JQuery {
   replaceWith(func: () => Element | JQuery): JQuery;
 
   /**
-   * Get the combined text contents of each element in the set of matched elements, including their descendants.
-   */
-  text(): string;
-  /**
    * Set the content of each element in the set of matched elements to the specified text.
    *
    * @param text The text to set as the content of each matched element. When Number or Boolean is supplied, it will be converted to a String representation.
@@ -2775,6 +2765,10 @@ declare class JQuery {
    * @param func A function returning the text content to set. Receives the index position of the element in the set and the old text value as arguments.
    */
   text(func: (index: number, text: string) => string): JQuery;
+  /**
+   * Get the combined text contents of each element in the set of matched elements, including their descendants.
+   */
+  text(): string;
 
   /**
    * Retrieve all the elements contained in the jQuery set, as an array.


### PR DESCRIPTION
See #78 and #74.

Also, chaining `.text()` & `.html()` with other methods does not work yet.