### PR TITLE
JQueryXHR now extends XMLHttpRequest and JQueryPromise

### DIFF
--- a/packages/iflow-jquery/index.js.flow
+++ b/packages/iflow-jquery/index.js.flow
@@ -179,7 +179,7 @@ declare interface JQueryAjaxSettings {
 /**
  * Interface for the jqXHR object
  */
-declare class JQueryXHR {
+declare class JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
   /**
    * The .overrideMimeType() method may be used in the beforeSend() callback function, for example, to modify the response content-type header. As of jQuery 1.5.1, the jqXHR object also contains the overrideMimeType() method (it was available in jQuery 1.4.x, as well, but was temporarily removed in jQuery 1.5).
    */


### PR DESCRIPTION
This fixes #75.

Basically [copying what DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jquery/index.d.ts#L171) does. This gives `JQueryXHR` the `done`, `fail`, and `always` methods.