### PR TITLE
JQueryAnimationOptions should be an interface

### DIFF
--- a/packages/iflow-jquery/index.js.flow
+++ b/packages/iflow-jquery/index.js.flow
@@ -572,7 +572,7 @@ declare class JQuerySerializeArrayElement {
   value: string;
 }
 
-declare class JQueryAnimationOptions {
+declare interface JQueryAnimationOptions {
   /**
    * A string or number determining how long the animation will run.
    */


### PR DESCRIPTION
This allows us to call [`animate`](https://github.com/marudor/flowInterfaces/blob/master/packages/iflow-jquery/index.js.flow#L1651) with a second argument that is an object literal.