### PR TITLE
Revert "JQueryXHR should extend XMLHttpRequest and JQueryPromise"

### DIFF
--- a/packages/iflow-jquery/index.js.flow
+++ b/packages/iflow-jquery/index.js.flow
@@ -179,7 +179,7 @@ declare interface JQueryAjaxSettings {
 /**
  * Interface for the jqXHR object
  */
-declare class JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
+declare class JQueryXHR {
   /**
    * The .overrideMimeType() method may be used in the beforeSend() callback function, for example, to modify the response content-type header. As of jQuery 1.5.1, the jqXHR object also contains the overrideMimeType() method (it was available in jQuery 1.4.x, as well, but was temporarily removed in jQuery 1.5).
    */


### PR DESCRIPTION
This reverts commit 911e94be87fe150c48e2ec42942e697ce1c27cfa and fixes #83.

Not sure how I didn't catch this when I submitted #81 😞

Maybe we should add tests to this repo? Or merge this into [flow-typed](https://github.com/flowtype/flow-typed) with some tests?

I'll re-open #75 once this PR is merged.