### PR TITLE
fix:The parameters of the Ajax callback function should be optional.

### DIFF
--- a/packages/iflow-jquery/index.js.flow
+++ b/packages/iflow-jquery/index.js.flow
@@ -36,7 +36,7 @@ declare interface JQueryAjaxSettings {
   /**
    * A pre-request callback function that can be used to modify the jqXHR (in jQuery 1.4.x, XMLHTTPRequest: any) object before it is sent. Use this to set custom headers, etc. The jqXHR and settings objects are passed as arguments. This is an Ajax Event. Returning false in the beforeSend function will cancel the request. As of jQuery 1.5, the beforeSend option will be called regardless of the type of request.
    */
-  beforeSend?: (jqXHR: JQueryXHR, settings: JQueryAjaxSettings) => any;
+  beforeSend?: (jqXHR?: JQueryXHR, settings?: JQueryAjaxSettings) => any;
   /**
    * If set to false, it will force requested pages not to be cached by the browser. Note: Setting cache to false will only work correctly with HEAD and GET requests. It works by appending "_={timestamp}" to the GET parameters. The parameter is not needed for other types of requests, except in IE8 when a POST is made to a URL that has already been requested by a GET.
    */
@@ -44,7 +44,7 @@ declare interface JQueryAjaxSettings {
   /**
    * A function to be called when the request finishes (after success and error callbacks are executed). The function gets passed two arguments: The jqXHR (in jQuery 1.4.x, XMLHTTPRequest: any) object and a string categorizing the status of the request ("success", "notmodified", "error", "timeout", "abort", or "parsererror"). As of jQuery 1.5, the complete setting can accept an array of functions. Each function will be called in turn. This is an Ajax Event.
    */
-  complete?: (jqXHR: JQueryXHR, textStatus: string) => any;
+  complete?: (jqXHR?: JQueryXHR, textStatus?: string) => any;
   /**
    * An object of string/regular-expression pairs that determine how jQuery will parse the response, given its content type. (version added: 1.5)
    */
@@ -78,7 +78,7 @@ declare interface JQueryAjaxSettings {
   /**
    * A function to be used to handle the raw response data of XMLHttpRequest.This is a pre-filtering function to sanitize the response. You should return the sanitized data. The function accepts two arguments: The raw data returned from the server and the 'dataType' parameter.
    */
-  dataFilter?: (data: any, ty: any) => any;
+  dataFilter?: (data?: any, ty?: any) => any;
   /**
    * The type of data that you're expecting back from the server. If none is specified, jQuery will try to infer it based on the MIME type of the response (an XML MIME type will yield XML, in 1.4 JSON will yield a JavaScript object, in 1.4 script will execute the script, and anything else will be returned as a string).
    */
@@ -86,7 +86,7 @@ declare interface JQueryAjaxSettings {
   /**
    * A function to be called if the request fails. The function receives three arguments: The jqXHR (in jQuery 1.4.x, XMLHttpRequest: any) object, a string describing the type of error that occurred and an optional exception object, if one occurred. Possible values for the second argument (besides null) are "timeout", "error", "abort", and "parsererror". When an HTTP error occurs, errorThrown receives the textual portion of the HTTP status, such as "Not Found" or "Internal Server Error." As of jQuery 1.5, the error setting can accept an array of functions. Each function will be called in turn. Note: This handler is not called for cross-domain script and cross-domain JSONP requests. This is an Ajax Event.
    */
-  error?: (jqXHR: JQueryXHR, textStatus: string, errorThrown: string) => any;
+  error?: (jqXHR?: JQueryXHR, textStatus?: string, errorThrown?: string) => any;
   /**
    * Whether to trigger global Ajax event handlers for this request. The default is true. Set to false to prevent the global handlers like ajaxStart or ajaxStop from being triggered. This can be used to control various Ajax Events.
    */
@@ -142,7 +142,7 @@ declare interface JQueryAjaxSettings {
   /**
    * A function to be called if the request succeeds. The function gets passed three arguments: The data returned from the server, formatted according to the dataType parameter; a string describing the status; and the jqXHR (in jQuery 1.4.x, XMLHttpRequest: any) object. As of jQuery 1.5, the success setting can accept an array of functions. Each function will be called in turn. This is an Ajax Event.
    */
-  success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any;
+  success?: (data?: any, textStatus?: string, jqXHR?: JQueryXHR) => any;
   /**
    * Set a timeout (in milliseconds) for the request. This will override any global timeout set with $.ajaxSetup(). The timeout period starts at the point the $.ajax call is made; if several other requests are in progress and the browser has no connections available, it is possible for a request to time out before it can be sent. In jQuery 1.4.x and below, the XMLHttpRequest object will be in an invalid state if the request times out; accessing any object members may throw an exception. In Firefox 3.0+ only, script and JSONP requests cannot be cancelled by a timeout; the script will run even if it arrives after the timeout period.
    */


### PR DESCRIPTION
I only need 'data'.
```JavaScript
$.ajax({
    success:function(data){
        doSometing(data);
    }
});
```